### PR TITLE
Remove duplicated 'Scores' section from lab1

### DIFF
--- a/integration/genaiops-langfuse-on-aws/lab1/lab1-langfuse-basics.ipynb
+++ b/integration/genaiops-langfuse-on-aws/lab1/lab1-langfuse-basics.ipynb
@@ -48,21 +48,7 @@
     "\n",
     "\n",
     "\n",
-    "## Scores\n",
-    "\n",
-    "Traces and observations can be evaluated using [scores](https://langfuse.com/docs/scores/overview). Scores are flexible objects that store evaluation metrics and can be:\n",
-    "\n",
-    "- Numeric, categorical, or boolean values\n",
-    "- Associated with a trace (required)\n",
-    "- Linked to a specific observation (optional)\n",
-    "- Annotated with comments for additional context\n",
-    "- Validated against a score configuration schema (optional)\n",
-    "\n",
-    "![Trace and Scores](./images/trace-scores.png)\n",
-    "\n",
-    "[Source](https://langfuse.com/docs/scores/overview)\n",
-    "\n",
-    "Please refer to the [scores documentation](https://langfuse.com/docs/scores/overview) to get started. For more details on score types and attributes, refer to the [score data model documentation](https://langfuse.com/docs/scores/data-model).\n"
+""
    ]
   },
   {


### PR DESCRIPTION
Remove the Markdown cell describing "Scores" (including explanatory text, image, and documentation links) from integration/genaiops-langfuse-on-aws/lab1/lab1-langfuse-basics.ipynb. Cleans up the notebook by deleting the outdated or redundant scoring documentation block.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
