### PR TITLE
Update build_sagemaker_pipeline.yml

### DIFF
--- a/platform/genai-ml-stdzn-on-smus/seed-code/classification/model_deploy/.github/workflows/build_sagemaker_pipeline.yml
+++ b/platform/genai-ml-stdzn-on-smus/seed-code/classification/model_deploy/.github/workflows/build_sagemaker_pipeline.yml
@@ -155,6 +155,9 @@ jobs:
         MODEL_VERSION=$(echo "$MODEL_PACKAGE_ARN" | cut -d'/' -f3 | tr '_' '-')
         SAGEMAKER_PROJECT_NAME=$(echo "$SAGEMAKER_PROJECT_NAME" | tr '_' '-')
         COMBINED="${SAGEMAKER_PROJECT_NAME}-${MODEL_PACKAGE_GROUP}-${MODEL_VERSION}"
+        if [[ "$COMBINED" =~ ^-+$ ]] || [[ -z "$COMBINED" ]]; then
+          COMBINED=""
+        fi
         echo "combined=$COMBINED" >> $GITHUB_OUTPUT
           
     - name: CDK Deploy


### PR DESCRIPTION
debug the deployment stack name error.

*Issue #, if available:*
stack name error while deployment.

*Description of changes:*
added the condition to check if the value is valid and make it empty so in the following steps while checking it can be ignored and the default value sagemaker-endpoint-stack could be used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
