### PR TITLE
Fixed script injection in seed-code workflow templates

### DIFF
--- a/platform/genai-ml-stdzn-on-smai/seed-code/classification/model_deploy/.github/workflows/deploy.yml
+++ b/platform/genai-ml-stdzn-on-smai/seed-code/classification/model_deploy/.github/workflows/deploy.yml
@@ -44,7 +44,9 @@ jobs:
     - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
     - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"
     - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-    - run: echo "The commit message for the event -\n ${{ github.event.head_commit.message }}"
+    - env:
+        COMMIT_MSG: ${{ github.event.head_commit.message }}
+      run: echo "The commit message for the event - $COMMIT_MSG"
     - uses: actions/checkout@v4
     - name: Check out repository code
       uses: actions/checkout@v4

--- a/platform/genai-ml-stdzn-on-smus/seed-code/classification/model_build/.github/workflows/build_sagemaker_pipeline.yml
+++ b/platform/genai-ml-stdzn-on-smus/seed-code/classification/model_build/.github/workflows/build_sagemaker_pipeline.yml
@@ -58,7 +58,9 @@ jobs:
     - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
     - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"
     - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-    - run: echo "The commit message for the event -\n ${{ github.event.head_commit.message }}"
+    - env:
+        COMMIT_MSG: ${{ github.event.head_commit.message }}
+      run: echo "The commit message for the event - $COMMIT_MSG"
     - uses: actions/checkout@v4
     - name: Check out repository code
       uses: actions/checkout@v4

--- a/platform/genai-ml-stdzn-on-smus/seed-code/classification/model_deploy/.github/workflows/build_sagemaker_pipeline.yml
+++ b/platform/genai-ml-stdzn-on-smus/seed-code/classification/model_deploy/.github/workflows/build_sagemaker_pipeline.yml
@@ -52,7 +52,9 @@ jobs:
     - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
     - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"
     - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-    - run: echo "The commit message for the event -\n ${{ github.event.head_commit.message }}"
+    - env:
+        COMMIT_MSG: ${{ github.event.head_commit.message }}
+      run: echo "The commit message for the event - $COMMIT_MSG"
     - uses: actions/checkout@v4
     - name: Check out repository code
       uses: actions/checkout@v4

--- a/platform/genai-ml-stdzn-on-smus/seed-code/regression/model_build/.github/workflows/build_sagemaker_pipeline.yml
+++ b/platform/genai-ml-stdzn-on-smus/seed-code/regression/model_build/.github/workflows/build_sagemaker_pipeline.yml
@@ -68,7 +68,9 @@ jobs:
     - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
     - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"
     - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-    - run: echo "The commit message for the event -\n ${{ github.event.head_commit.message }}"
+    - env:
+        COMMIT_MSG: ${{ github.event.head_commit.message }}
+      run: echo "The commit message for the event - $COMMIT_MSG"
     - uses: actions/checkout@v4
     - name: Check out repository code
       uses: actions/checkout@v4

--- a/platform/genai-ml-stdzn-on-smus/seed-code/regression/model_deploy/.github/workflows/deploy_model_pipeline.yml
+++ b/platform/genai-ml-stdzn-on-smus/seed-code/regression/model_deploy/.github/workflows/deploy_model_pipeline.yml
@@ -39,7 +39,9 @@ jobs:
     - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
     - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"
     - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-    - run: echo "The commit message for the event -\n ${{ github.event.head_commit.message }}"
+    - env:
+        COMMIT_MSG: ${{ github.event.head_commit.message }}
+      run: echo "The commit message for the event - $COMMIT_MSG"
     - uses: actions/checkout@v4
     - name: Check out repository code
       uses: actions/checkout@v4


### PR DESCRIPTION
  The commit message was being interpolated directly into a run: block,
  which lets a crafted commit message execute arbitrary shell commands
  on the runner. Use an env variable instead so bash treats it as data.

  Applied to all 5 affected workflows across smus and smai seed-code.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
